### PR TITLE
Fix clippy violations in milestone2 xtask gates

### DIFF
--- a/xtask/src/main/milestone2_gates.rs
+++ b/xtask/src/main/milestone2_gates.rs
@@ -621,8 +621,11 @@ fn run_perf_self_test(root: &Path) -> Result<(), String> {
         &fs::read(&path).map_err(|e| format!("read perf self-test artifact: {e}"))?,
     )
     .map_err(|e| format!("parse perf self-test artifact: {e}"))?;
-    if parsed["schema_version"] != Value::from(1)
-        || parsed["aggregation_mode"] != Value::from("median")
+    if parsed.get("schema_version").and_then(Value::as_i64) != Some(1)
+        || parsed
+            .get("aggregation_mode")
+            .and_then(Value::as_str)
+            != Some("median")
     {
         return Err("perf self-test failed: artifact schema mismatch".into());
     }
@@ -1131,7 +1134,7 @@ fn recurse_files(base: &Path, out: &mut Vec<PathBuf>, target_name: &str, skip_di
             let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };
-            if skip_dirs.iter().any(|skip| *skip == name) {
+            if skip_dirs.contains(&name) {
                 continue;
             }
             recurse_files(&path, out, target_name, skip_dirs);


### PR DESCRIPTION
## Summary

This PR fixes CI-blocking clippy findings in milestone_2 xtask gates:

- Replaced owned JSON comparisons with typed field checks in `run_perf_self_test`.
- Replaced manual `iter().any(...)` directory-skip check with `contains(...)` in `recurse_files`.

Why: `cargo clippy --workspace --all-targets -- -D warnings` failed on these items, which blocked release-readiness checks.

## Checklist

- [x] I ran `cargo fmt --all -- --check`
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`
- [x] I ran `cargo test --workspace`
- [ ] I updated tests for behavior changes (not needed: no behavior change)
- [ ] I updated docs for user-facing changes (not needed: internal lint fix)

## Related Issues

Closes #
